### PR TITLE
Change: add upload-date to packet size validation

### DIFF
--- a/bananas_api/new_upload/session_validation.py
+++ b/bananas_api/new_upload/session_validation.py
@@ -85,7 +85,7 @@ def validate_packet_size(session, package):
     # Calculate if this entry wouldn't exceed the OpenTTD packet size if
     # we would transmit this over the wire.
 
-    size = 1 + 4 + 4  # content-type, content-id, filesize
+    size = 1 + 4 + 4 + 4  # content-type, content-id, filesize, upload-date
     size += len(session.get("name", package.get("name", ""))) + 2
     size += len(session.get("version", "")) + 2
     size += len(session.get("url", package.get("url", ""))) + 2


### PR DESCRIPTION
Adding the upload-date size (4 bytes) to the packet size validation that makes sure packets don't exceed OpenTTD packet size.

This change pairs up with https://github.com/OpenTTD/bananas-server/pull/43 and https://github.com/OpenTTD/OpenTTD/pull/8902 which aim to pass the content upload-date to OpenTTD so it can be used to display it and for being able to sort by upload date in the network content window.